### PR TITLE
Implement the bundle parameter in multirootca authsign

### DIFF
--- a/cmd/multirootca/bundler.go
+++ b/cmd/multirootca/bundler.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"crypto/x509"
+
+	"github.com/cloudflare/cfssl/bundler"
+	"github.com/cloudflare/cfssl/log"
+)
+
+type MultirootBundler struct {
+	*bundler.Bundler
+}
+
+// NewMultirootBundler will set up a bundler with the systems root store
+// as caBundle. Intermediate certificates can be added later via AddIntermediate()
+func NewMultirootBundler() (*MultirootBundler, error) {
+	b, err := bundler.NewBundlerFromPEM(nil, nil)
+	if err != nil {
+		log.Errorf("failed creating empty bundler")
+		return nil, err
+	}
+	return &MultirootBundler{Bundler: b}, nil
+}
+
+func (m *MultirootBundler) AddRoot(cert *x509.Certificate) {
+	// Initialize a RootPool then the first root cert is added
+	// If none is added, systems root store will be used
+	if m.Bundler.RootPool == nil {
+		m.Bundler.RootPool = x509.NewCertPool()
+	}
+	m.Bundler.RootPool.AddCert(cert)
+	m.Bundler.KnownIssuers[string(cert.Signature)] = true
+}
+
+func (m *MultirootBundler) AddIntermediate(cert *x509.Certificate) {
+	m.Bundler.IntermediatePool.AddCert(cert)
+	m.Bundler.KnownIssuers[string(cert.Signature)] = true
+}

--- a/cmd/multirootca/ca.go
+++ b/cmd/multirootca/ca.go
@@ -43,6 +43,7 @@ func parseSigner(root *config.Root) (signer.Signer, error) {
 
 var (
 	defaultLabel string
+	mrBundler    *MultirootBundler
 	signers      = map[string]signer.Signer{}
 	whitelists   = map[string]whitelist.NetACL{}
 )
@@ -65,6 +66,11 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 
+	mrBundler, err = NewMultirootBundler()
+	if err != nil {
+		log.Fatalf("error creating MultirootBundler: %v", err)
+	}
+
 	for label, root := range roots {
 		s, err := parseSigner(root)
 		if err != nil {
@@ -75,6 +81,13 @@ func main() {
 			whitelists[label] = root.ACL
 		}
 		log.Info("loaded signer ", label)
+
+		if root.RootCA != nil {
+			mrBundler.AddRoot(root.RootCA)
+			log.Info("loaded root CA ", label)
+		}
+		mrBundler.AddIntermediate(root.Certificate)
+		log.Info("loaded intermediate ", label)
 	}
 
 	defaultLabel = *flagDefaultLabel

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -74,6 +74,10 @@ type SignRequest struct {
 
 	// Arbitrary metadata to be stored in certdb.
 	Metadata map[string]interface{} `json:"metadata"`
+
+	// Bundle is a boolean specifying whether to include an "optimal"
+	// certificate bundle along with the certificate
+	Bundle bool `json:"bundle,omitempty"`
 }
 
 // appendIf appends to a if s is not an empty string.


### PR DESCRIPTION
/api/v1/cfssl/authsign now supports the bundle parameter and returns an
"optimal" bundle in case it is set in a request (as documented in
cfssl/doc/api/endpoint_authsign.txt