### PR TITLE
Make BundleSign/BundleAuthSign return the root CA as well

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -38,9 +38,9 @@ type server struct {
 // are used by the remote.
 type Remote interface {
 	AuthSign(req, id []byte, provider auth.Provider) ([]byte, error)
-	BundleAuthSign(req, id []byte, provider auth.Provider) ([]byte, error)
+	BundleAuthSign(req, id []byte, provider auth.Provider) ([]byte, []byte, error)
 	Sign(jsonData []byte) ([]byte, error)
-	BundleSign(jsonData []byte) ([]byte, error)
+	BundleSign(jsonData []byte) ([]byte, []byte, error)
 	Info(jsonData []byte) (*info.Resp, error)
 	Hosts() []string
 	SetReqModifier(func(*http.Request, []byte))
@@ -192,7 +192,8 @@ func (srv *server) post(url string, jsonData []byte) (*api.Response, error) {
 // It takes the serialized JSON request to send, remote address and
 // authentication provider.
 func (srv *server) AuthSign(req, id []byte, provider auth.Provider) ([]byte, error) {
-	return srv.authReq(req, id, provider, "sign", false)
+	_, cert, err := srv.authReq(req, id, provider, "sign", false)
+	return cert, err
 }
 
 // BundleAuthSign fills out an authenticated signing request to the server,
@@ -201,7 +202,7 @@ func (srv *server) AuthSign(req, id []byte, provider auth.Provider) ([]byte, err
 // It takes the serialized JSON request to send which is required to
 // have the bundle parameter set to true, remote address and authentication
 // provider.
-func (srv *server) BundleAuthSign(req, id []byte, provider auth.Provider) ([]byte, error) {
+func (srv *server) BundleAuthSign(req, id []byte, provider auth.Provider) ([]byte, []byte, error) {
 	return srv.authReq(req, id, provider, "sign", true)
 }
 
@@ -210,18 +211,19 @@ func (srv *server) BundleAuthSign(req, id []byte, provider auth.Provider) ([]byt
 // It takes the serialized JSON request to send, remote address and
 // authentication provider.
 func (srv *server) AuthInfo(req, id []byte, provider auth.Provider) ([]byte, error) {
-	return srv.authReq(req, id, provider, "info", false)
+	_, cert, err := srv.authReq(req, id, provider, "info", false)
+	return cert, err
 }
 
 // authReq is the common logic for AuthSign and AuthInfo -- perform the given
 // request, and return the resultant certificate.
 // The target is either 'sign' or 'info'.
-func (srv *server) authReq(req, ID []byte, provider auth.Provider, target string, returnBundle bool) ([]byte, error) {
+func (srv *server) authReq(req, ID []byte, provider auth.Provider, target string, returnBundle bool) ([]byte, []byte, error) {
 	url := srv.getURL("auth" + target)
 
 	token, err := provider.Token(req)
 	if err != nil {
-		return nil, errors.Wrap(errors.APIClientError, errors.AuthenticationFailure, err)
+		return nil, nil, errors.Wrap(errors.APIClientError, errors.AuthenticationFailure, err)
 	}
 
 	aReq := &auth.AuthenticatedRequest{
@@ -233,41 +235,43 @@ func (srv *server) authReq(req, ID []byte, provider auth.Provider, target string
 
 	jsonData, err := json.Marshal(aReq)
 	if err != nil {
-		return nil, errors.Wrap(errors.APIClientError, errors.JSONError, err)
+		return nil, nil, errors.Wrap(errors.APIClientError, errors.JSONError, err)
 	}
 
 	response, err := srv.post(url, jsonData)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	result, ok := response.Result.(map[string]interface{})
 	if !ok {
-		return nil, errors.New(errors.APIClientError, errors.JSONError)
+		return nil, nil, errors.New(errors.APIClientError, errors.JSONError)
 	}
 
-	var cert string
+	var ca, cert string
 	if returnBundle {
 		bundle, okBundle := result["bundle"].(map[string]interface{})
 		if !okBundle {
-			return nil, errors.New(errors.APIClientError, errors.JSONError)
+			return nil, nil, errors.New(errors.APIClientError, errors.JSONError)
 		}
 		cert, ok = bundle["bundle"].(string)
+		ca, _ = bundle["root"].(string)
 	} else {
 		cert, ok = result["certificate"].(string)
 	}
 	if !ok {
-		return nil, errors.New(errors.APIClientError, errors.JSONError)
+		return nil, nil, errors.New(errors.APIClientError, errors.JSONError)
 	}
 
-	return []byte(cert), nil
+	return []byte(ca), []byte(cert), nil
 }
 
 // Sign sends a signature request to the remote CFSSL server,
 // receiving a signed certificate or an error in response.
 // It takes the serialized JSON request to send.
 func (srv *server) Sign(jsonData []byte) ([]byte, error) {
-	return srv.request(jsonData, "sign", false)
+	_, cert, err := srv.request(jsonData, "sign", false)
+	return cert, err
 }
 
 // BundleSign sends a signature request to the remote CFSSL server,
@@ -275,7 +279,7 @@ func (srv *server) Sign(jsonData []byte) ([]byte, error) {
 // in response.
 // It takes the serialized JSON request to send which is required to
 // have the bundle parameter set to true.
-func (srv *server) BundleSign(jsonData []byte) ([]byte, error) {
+func (srv *server) BundleSign(jsonData []byte) ([]byte, []byte, error) {
 	return srv.request(jsonData, "sign", true)
 }
 
@@ -325,19 +329,19 @@ func (srv *server) getResultMap(jsonData []byte, target string) (result map[stri
 
 // request performs the common logic for Sign and Info, performing the actual
 // request and returning the resultant certificate or bundle.
-func (srv *server) request(jsonData []byte, target string, returnBundle bool) ([]byte, error) {
+func (srv *server) request(jsonData []byte, target string, returnBundle bool) ([]byte, []byte, error) {
 	result, err := srv.getResultMap(jsonData, target)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	var key string
-	var cert string
+	var ca, cert, key string
 	if returnBundle {
 		key = "bundle"
 		bundle, okBundle := result[key].(map[string]interface{})
 		if okBundle {
 			cert = bundle[key].(string)
+			ca = bundle["root"].(string)
 		}
 	} else {
 		key = "certificate"
@@ -345,10 +349,10 @@ func (srv *server) request(jsonData []byte, target string, returnBundle bool) ([
 	}
 
 	if cert != "" {
-		return []byte(cert), nil
+		return []byte(ca), []byte(cert), nil
 	}
 
-	return nil, errors.Wrap(errors.APIClientError, errors.ClientHTTPError, stderr.New(fmt.Sprintf("response doesn't contain %s.", key)))
+	return nil, nil, errors.Wrap(errors.APIClientError, errors.ClientHTTPError, stderr.New(fmt.Sprintf("response doesn't contain %s.", key)))
 }
 
 // AuthRemote acts as a Remote with a default Provider for AuthSign.
@@ -373,7 +377,7 @@ func (ar *AuthRemote) Sign(req []byte) ([]byte, error) {
 }
 
 // BundleSign is overloaded to perform an BundleAuthSign request using the default auth provider.
-func (ar *AuthRemote) BundleSign(req []byte) ([]byte, error) {
+func (ar *AuthRemote) BundleSign(req []byte) ([]byte, []byte, error) {
 	return ar.BundleAuthSign(req, nil, ar.provider)
 }
 

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -73,7 +73,7 @@ func TestBundleAuthSign(t *testing.T) {
 	testProvider, _ = auth.New(testKey, nil)
 	s := NewAuthServer("1.1.1.1", nil, testProvider)
 	testRequest := []byte(`testing 1 2 3`)
-	as, err := s.BundleAuthSign(testRequest, testAD, testProvider)
+	_, as, err := s.BundleAuthSign(testRequest, testAD, testProvider)
 	if as != nil || err == nil {
 		t.Fatal("expected error with auth sign function")
 	}
@@ -99,7 +99,7 @@ func TestSign(t *testing.T) {
 
 func TestBundleSign(t *testing.T) {
 	s := NewServer("1.1.1.1")
-	sign, err := s.BundleSign([]byte{5, 5, 5, 5})
+	_, sign, err := s.BundleSign([]byte{5, 5, 5, 5})
 	if sign != nil || err == nil {
 		t.Fatalf("expected error with sign function")
 	}

--- a/api/client/group.go
+++ b/api/client/group.go
@@ -104,15 +104,15 @@ func (g *orderedListGroup) AuthSign(req, id []byte, provider auth.Provider) (res
 	return nil, err
 }
 
-func (g *orderedListGroup) BundleAuthSign(req, id []byte, provider auth.Provider) (resp []byte, err error) {
+func (g *orderedListGroup) BundleAuthSign(req, id []byte, provider auth.Provider) (ca []byte, cert []byte, err error) {
 	for i := range g.remotes {
-		resp, err = g.remotes[i].BundleAuthSign(req, id, provider)
+		ca, cert, err = g.remotes[i].BundleAuthSign(req, id, provider)
 		if err == nil {
-			return resp, nil
+			return ca, cert, nil
 		}
 	}
 
-	return nil, err
+	return nil, nil, err
 }
 
 func (g *orderedListGroup) Sign(jsonData []byte) (resp []byte, err error) {
@@ -126,15 +126,15 @@ func (g *orderedListGroup) Sign(jsonData []byte) (resp []byte, err error) {
 	return nil, err
 }
 
-func (g *orderedListGroup) BundleSign(jsonData []byte) (resp []byte, err error) {
+func (g *orderedListGroup) BundleSign(jsonData []byte) (ca []byte, cert []byte, err error) {
 	for i := range g.remotes {
-		resp, err = g.remotes[i].BundleSign(jsonData)
+		ca, cert, err = g.remotes[i].BundleSign(jsonData)
 		if err == nil {
-			return resp, nil
+			return ca, cert, nil
 		}
 	}
 
-	return nil, err
+	return nil, nil, err
 }
 
 func (g *orderedListGroup) Info(jsonData []byte) (resp *info.Resp, err error) {


### PR DESCRIPTION
This extends the BundleSign/BundleAuthSign API to return the root CA
provided in the bundle response as well.

https://phabricator.wikimedia.org/T299906